### PR TITLE
Make fields property optional on SimpleMessagesProvider

### DIFF
--- a/src/messages_provider/simple_messages_provider.ts
+++ b/src/messages_provider/simple_messages_provider.ts
@@ -22,9 +22,9 @@ export class SimpleMessagesProvider implements MessagesProviderContact {
   #messages: ValidationMessages
   #fields: ValidationFields
 
-  constructor(messages: ValidationMessages, fields: ValidationFields) {
+  constructor(messages: ValidationMessages, fields?: ValidationFields) {
     this.#messages = messages
-    this.#fields = fields
+    this.#fields = fields || {}
   }
 
   /**


### PR DESCRIPTION
this PR makes the `fields` property optional on `SimpleMessagesProvider`

on [docs](https://vinejs.dev/docs/custom_error_messages#using-the-simplemessagesprovider), I see that the `fields` property is not required on `SimpleMessagesProvider`


**Now if you want to use `SimpleMessagesProvider` you need to pass a second argument**

```ts
new SimpleMessagesProvider({
  'required': 'The {{ field }} field is required',
}, {})
```
