### PR TITLE
Serialize SimpleMessagesProvider into JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@japa/assert": "^2.0.0-1",
     "@japa/expect-type": "^2.0.0-0",
     "@japa/runner": "^3.0.0-6",
-    "@swc/core": "^1.3.70",
+    "@swc/core": "1.3.82",
     "@types/node": "^20.4.2",
     "benchmark": "^2.1.4",
     "c8": "^8.0.1",

--- a/src/messages_provider/simple_messages_provider.ts
+++ b/src/messages_provider/simple_messages_provider.ts
@@ -87,4 +87,11 @@ export class SimpleMessagesProvider implements MessagesProviderContact {
       ...args,
     })
   }
+
+  toJSON() {
+    return {
+      messages: this.#messages,
+      fields: this.#fields,
+    }
+  }
 }

--- a/tests/unit/simple_messages_provider.spec.ts
+++ b/tests/unit/simple_messages_provider.spec.ts
@@ -171,7 +171,7 @@ test.group('Simple messages provider', () => {
       }
     )
 
-    assert.equal(provider.toJSON(), {
+    assert.deepEqual(provider.toJSON(), {
       messages: {
         required: 'The {{ field }} field is required',
         string: 'The value of {{ field }} field must be a string',

--- a/tests/unit/simple_messages_provider.spec.ts
+++ b/tests/unit/simple_messages_provider.spec.ts
@@ -156,3 +156,31 @@ test.group('Simple messages provider | interpolation', () => {
     )
   })
 })
+
+test.group('Simple messages provider', () => {
+  test('serialize to json', ({ assert }) => {
+    const provider = new SimpleMessagesProvider(
+      {
+        required: 'The {{ field }} field is required',
+        string: 'The value of {{ field }} field must be a string',
+        email: 'The value is not a valid email address',
+      },
+      {
+        first_name: 'first name',
+        last_name: 'last name',
+      }
+    )
+
+    assert.equal(provider.toJSON(), {
+      messages: {
+        required: 'The {{ field }} field is required',
+        string: 'The value of {{ field }} field must be a string',
+        email: 'The value is not a valid email address',
+      },
+      fields: {
+        first_name: 'first name',
+        last_name: 'last name',
+      },
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for JSON serialization of `SimpleMessagesProvider` class


### Before
![CleanShot 2023-09-27 at 08 51 13](https://github.com/vinejs/vine/assets/6713842/c531ca6e-35d3-4ef9-9ea9-7d06f7f2c64f)


### After
![CleanShot 2023-09-27 at 08 52 17](https://github.com/vinejs/vine/assets/6713842/f49a0b4d-4862-4644-b485-a71a2251ab36)

