### PR TITLE
Export base schema classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     ".": "./build/index.js",
     "./defaults": "./build/src/defaults.js",
     "./factories": "./build/factories/main.js",
-    "./types": "./build/src/types.js"
+    "./types": "./build/src/types.js",
+    "./schema/base/*": "./build/src/schema/*.js"
   },
   "scripts": {
     "pretest": "npm run lint",

--- a/src/schema/base/literal.ts
+++ b/src/schema/base/literal.ts
@@ -80,7 +80,7 @@ abstract class BaseModifiersType<Output, CamelCaseOutput>
 /**
  * Modifies the schema type to allow null values
  */
-class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
+export class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
   Schema[typeof OTYPE] | null,
   Schema[typeof COTYPE] | null
 > {
@@ -111,7 +111,7 @@ class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
 /**
  * Modifies the schema type to allow undefined values
  */
-class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
+export class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
   Schema[typeof OTYPE] | undefined,
   Schema[typeof COTYPE] | undefined
 > {
@@ -142,7 +142,7 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
 /**
  * Modifies the schema type to allow custom transformed values
  */
-class TransformModifier<
+export class TransformModifier<
   Schema extends BaseModifiersType<any, any>,
   Output,
 > extends BaseModifiersType<Output, Output> {

--- a/src/schema/base/main.ts
+++ b/src/schema/base/main.ts
@@ -68,7 +68,7 @@ export abstract class BaseModifiersType<Output, CamelCaseOutput>
 /**
  * Modifies the schema type to allow null values
  */
-class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
+export class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
   Schema[typeof OTYPE] | null,
   Schema[typeof COTYPE] | null
 > {
@@ -102,7 +102,7 @@ class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
 /**
  * Modifies the schema type to allow undefined values
  */
-class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
+export class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseModifiersType<
   Schema[typeof OTYPE] | undefined,
   Schema[typeof COTYPE] | undefined
 > {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a vine validator is exported by another package (e.g. a common package in a monorepo), which is built by tsc it cannot be compiled since tsc cant reference the schema base classes. By exporting the classes and including the path in the `package.json` exports this gets fixed.
 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
