### PR TITLE
feat: implement requiredIf rules

### DIFF
--- a/src/schema/base/literal.ts
+++ b/src/schema/base/literal.ts
@@ -89,15 +89,9 @@ class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
 > {
   #parent: Schema
 
-  /**
-   * Optional modifier validations list
-   */
-  validations: Validation<any>[]
-
-  constructor(parent: Schema, validations?: Validation<any>[]) {
+  constructor(parent: Schema) {
     super()
     this.#parent = parent
-    this.validations = validations || []
   }
 
   /**

--- a/src/schema/base/literal.ts
+++ b/src/schema/base/literal.ts
@@ -265,7 +265,7 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
    * one of the other fields are present with non-nullable
    * value.
    */
-  requiredIfExistsAny(fields: string[]) {
+  requiredIfAnyExists(fields: string[]) {
     return this.use(
       requiredWhen((field) => {
         return fields.some((otherField) =>
@@ -295,7 +295,7 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
    * Mark the field under validation as required when any
    * one of the other fields are missing.
    */
-  requiredIfMissingAny(fields: string[]) {
+  requiredIfAnyMissing(fields: string[]) {
     return this.use(
       requiredWhen((field) => {
         return fields.some((otherField) =>

--- a/src/schema/base/literal.ts
+++ b/src/schema/base/literal.ts
@@ -17,10 +17,13 @@ import type {
   Validation,
   RuleBuilder,
   Transformer,
+  FieldContext,
   FieldOptions,
   ParserOptions,
   ConstructableSchema,
 } from '../../types.js'
+import { requiredWhen } from './rules.js'
+import { helpers } from '../../vine/helpers.js'
 
 /**
  * Base schema type with only modifiers applicable on all the schema types.
@@ -51,8 +54,8 @@ abstract class BaseModifiersType<Output, CamelCaseOutput>
    * Mark the field under validation as optional. An optional
    * field allows both null and undefined values.
    */
-  optional(): OptionalModifier<this> {
-    return new OptionalModifier(this)
+  optional(validations?: Validation<any>[]): OptionalModifier<this> {
+    return new OptionalModifier(this, validations)
   }
 
   /**
@@ -85,9 +88,16 @@ class NullableModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
   Schema[typeof COTYPE] | null
 > {
   #parent: Schema
-  constructor(parent: Schema) {
+
+  /**
+   * Optional modifier validations list
+   */
+  validations: Validation<any>[]
+
+  constructor(parent: Schema, validations?: Validation<any>[]) {
     super()
     this.#parent = parent
+    this.validations = validations || []
   }
 
   /**
@@ -116,9 +126,126 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
   Schema[typeof COTYPE] | undefined
 > {
   #parent: Schema
-  constructor(parent: Schema) {
+
+  /**
+   * Optional modifier validations list
+   */
+  validations: Validation<any>[]
+
+  constructor(parent: Schema, validations?: Validation<any>[]) {
     super()
     this.#parent = parent
+    this.validations = validations || []
+  }
+
+  /**
+   * Shallow clones the validations. Since, there are no API's to mutate
+   * the validation options, we can safely copy them by reference.
+   */
+  protected cloneValidations(): Validation<any>[] {
+    return this.validations.map((validation) => {
+      return {
+        options: validation.options,
+        rule: validation.rule,
+      }
+    })
+  }
+
+  /**
+   * Compiles validations
+   */
+  protected compileValidations(refs: RefsStore) {
+    return this.validations.map((validation) => {
+      return {
+        ruleFnId: refs.track({
+          validator: validation.rule.validator,
+          options: validation.options,
+        }),
+        implicit: validation.rule.implicit,
+        isAsync: validation.rule.isAsync,
+      }
+    })
+  }
+
+  /**
+   * Push a validation to the validations chain.
+   */
+  use(validation: Validation<any> | RuleBuilder): this {
+    this.validations.push(VALIDATION in validation ? validation[VALIDATION]() : validation)
+    return this
+  }
+
+  /**
+   * Define a callback to conditionally require a field at
+   * runtime.
+   *
+   * The callback method should return "true" to mark the
+   * field as required, or "false" to skip the required
+   * validation
+   */
+  requiredWhen(callback: (field: FieldContext) => boolean) {
+    return this.use(requiredWhen(callback))
+  }
+
+  /**
+   * Mark the field under validation as required when all
+   * the other fields are present with value other
+   * than `undefined` or `null`.
+   */
+  requiredIfExists(fields: string | string[]) {
+    const fieldsToExist = Array.isArray(fields) ? fields : [fields]
+    return this.use(
+      requiredWhen((field) => {
+        return fieldsToExist.every((otherField) =>
+          helpers.exists(helpers.getNestedValue(otherField, field))
+        )
+      })
+    )
+  }
+
+  /**
+   * Mark the field under validation as required when any
+   * one of the other fields are present with non-nullable
+   * value.
+   */
+  requiredIfExistsAny(fields: string[]) {
+    return this.use(
+      requiredWhen((field) => {
+        return fields.some((otherField) =>
+          helpers.exists(helpers.getNestedValue(otherField, field))
+        )
+      })
+    )
+  }
+
+  /**
+   * Mark the field under validation as required when all
+   * the other fields are missing or their value is
+   * `undefined` or `null`.
+   */
+  requiredIfMissing(fields: string | string[]) {
+    const fieldsToExist = Array.isArray(fields) ? fields : [fields]
+    return this.use(
+      requiredWhen((field) => {
+        return fieldsToExist.every((otherField) =>
+          helpers.isMissing(helpers.getNestedValue(otherField, field))
+        )
+      })
+    )
+  }
+
+  /**
+   * Mark the field under validation as required when any
+   * one of the other fields are missing.
+   */
+  requiredIfMissingAny(fields: string[]) {
+    return this.use(
+      requiredWhen((field) => {
+        return fields.some((otherField) =>
+          helpers.isMissing(helpers.getNestedValue(otherField, field))
+        )
+      })
+    )
   }
 
   /**
@@ -126,7 +253,7 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
    * and wraps it inside the optional modifier
    */
   clone(): this {
-    return new OptionalModifier(this.#parent.clone()) as this
+    return new OptionalModifier(this.#parent.clone(), this.cloneValidations()) as this
   }
 
   /**
@@ -135,6 +262,7 @@ class OptionalModifier<Schema extends BaseModifiersType<any, any>> extends BaseM
   [PARSE](propertyName: string, refs: RefsStore, options: ParserOptions): LiteralNode {
     const output = this.#parent[PARSE](propertyName, refs, options)
     output.isOptional = true
+    output.validations = output.validations.concat(this.compileValidations(refs))
     return output
   }
 }

--- a/src/schema/base/rules.ts
+++ b/src/schema/base/rules.ts
@@ -1,0 +1,28 @@
+/*
+ * @vinejs/vine
+ *
+ * (c) VineJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { messages } from '../../defaults.js'
+import type { FieldContext } from '../../types.js'
+import { createRule } from '../../vine/create_rule.js'
+
+/**
+ * Validates the value to be required when a certain condition
+ * is matched
+ */
+export const requiredWhen = createRule<(field: FieldContext) => boolean>(
+  (_, checker, field) => {
+    const shouldBeRequired = checker(field)
+    if (!field.isDefined && shouldBeRequired) {
+      field.report(messages.required, 'required', field)
+    }
+  },
+  {
+    implicit: true,
+  }
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,3 +270,11 @@ export type ValidationOptions<MetaData extends Record<string, any> | undefined> 
  * Infers the schema type
  */
 export type Infer<Schema extends { [OTYPE]: any }> = Schema[typeof OTYPE]
+
+/**
+ * Comparison operators supported by requiredWhen
+ * rule
+ */
+export type NumericComparisonOperators = '>' | '<' | '>=' | '<='
+export type ArrayComparisonOperators = 'in' | 'notIn'
+export type ComparisonOperators = ArrayComparisonOperators | NumericComparisonOperators | '=' | '!='

--- a/tests/integration/schema/conditional_required.spec.ts
+++ b/tests/integration/schema/conditional_required.spec.ts
@@ -1,0 +1,309 @@
+/*
+ * @vinejs/vine
+ *
+ * (c) VineJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import vine from '../../../index.js'
+import { helpers } from '../../../src/vine/helpers.js'
+
+test.group('requiredIfExists', () => {
+  test('fail when value is missing but other field exists', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      password: vine.string().optional().requiredIfExists('email'),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'password',
+        message: 'The password field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('pass when value is missing but other field does not exist', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      password: vine.string().optional().requiredIfExists('email'),
+    })
+
+    const data = {}
+
+    await assert.validationOutput(vine.validate({ schema, data }), {})
+  })
+
+  test('pass when value exists but other field does not exist', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      password: vine.string().optional().requiredIfExists('email'),
+    })
+
+    const data = {
+      password: 'foo',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      password: 'foo',
+    })
+  })
+
+  test('do not fail until all the other fields exists', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      password: vine.string().optional().requiredIfExists(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+    })
+  })
+
+  test('fail if all the other fields exists', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      password: vine.string().optional().requiredIfExists(['email', 'username']),
+    })
+
+    const data = {
+      username: 'foo',
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'password',
+        message: 'The password field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+})
+
+test.group('requiredIfExistsAny', () => {
+  test('fail if value is missing and any one of the other field is present', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      password: vine.string().optional().requiredIfExistsAny(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'password',
+        message: 'The password field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('pass if value is present', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      password: vine.string().optional().requiredIfExistsAny(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+      password: 'secret',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+      password: 'secret',
+    })
+  })
+})
+
+test.group('requiredIfMissing', () => {
+  test('fail when value is missing and other field is missing as well', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional().requiredIfMissing('email'),
+    })
+
+    const data = {}
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'username',
+        message: 'The username field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('pass when value is missing but other field is present', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional().requiredIfMissing('email'),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+    })
+  })
+
+  test('pass when value both the fields exist', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional().requiredIfMissing('email'),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+      username: 'foo',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+      username: 'foo',
+    })
+  })
+
+  test('do not fail until all other fields are missing', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      githubId: vine.string().optional().requiredIfMissing(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+    })
+  })
+
+  test('fail if all the other fields are missing', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      githubId: vine.string().optional().requiredIfMissing(['email', 'username']),
+    })
+
+    const data = {}
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'githubId',
+        message: 'The githubId field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+})
+
+test.group('requiredIfMissingAny', () => {
+  test('fail if value is missing and any one of the other field is missing', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      githubId: vine.string().optional().requiredIfMissingAny(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+    }
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'githubId',
+        message: 'The githubId field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('pass if all other fields are present', async ({ assert }) => {
+    const schema = vine.object({
+      email: vine.string().optional(),
+      username: vine.string().optional(),
+      githubId: vine.string().optional().requiredIfMissingAny(['email', 'username']),
+    })
+
+    const data = {
+      email: 'foo@bar.com',
+      username: 'foo',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      email: 'foo@bar.com',
+      username: 'foo',
+    })
+  })
+})
+
+test.group('requiredWhen | optional', () => {
+  test('fail when required field is missing', async ({ assert }) => {
+    const schema = vine.object({
+      game: vine.string().optional(),
+      teamName: vine
+        .string()
+        .optional()
+        .requiredWhen((field) => {
+          return helpers.exists(field.data.game) && field.data.game === 'volleyball'
+        }),
+    })
+
+    const data = {
+      game: 'volleyball',
+    }
+
+    await assert.validationErrors(vine.validate({ schema, data }), [
+      {
+        field: 'teamName',
+        message: 'The teamName field must be defined',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('pass when required field is defined', async ({ assert }) => {
+    const schema = vine.object({
+      game: vine.string().optional(),
+      teamName: vine
+        .string()
+        .optional()
+        .requiredWhen((field) => {
+          return helpers.exists(field.data.game) && field.data.game === 'volleyball'
+        }),
+    })
+
+    const data = {
+      game: 'volleyball',
+      teamName: 'foo',
+    }
+
+    await assert.validationOutput(vine.validate({ schema, data }), {
+      game: 'volleyball',
+      teamName: 'foo',
+    })
+  })
+})

--- a/tests/integration/schema/conditional_required.spec.ts
+++ b/tests/integration/schema/conditional_required.spec.ts
@@ -94,12 +94,12 @@ test.group('requiredIfExists', () => {
   })
 })
 
-test.group('requiredIfExistsAny', () => {
+test.group('requiredIfAnyExists', () => {
   test('fail if value is missing and any one of the other field is present', async ({ assert }) => {
     const schema = vine.object({
       email: vine.string().optional(),
       username: vine.string().optional(),
-      password: vine.string().optional().requiredIfExistsAny(['email', 'username']),
+      password: vine.string().optional().requiredIfAnyExists(['email', 'username']),
     })
 
     const data = {
@@ -119,7 +119,7 @@ test.group('requiredIfExistsAny', () => {
     const schema = vine.object({
       email: vine.string().optional(),
       username: vine.string().optional(),
-      password: vine.string().optional().requiredIfExistsAny(['email', 'username']),
+      password: vine.string().optional().requiredIfAnyExists(['email', 'username']),
     })
 
     const data = {
@@ -219,12 +219,12 @@ test.group('requiredIfMissing', () => {
   })
 })
 
-test.group('requiredIfMissingAny', () => {
+test.group('requiredIfAnyMissing', () => {
   test('fail if value is missing and any one of the other field is missing', async ({ assert }) => {
     const schema = vine.object({
       email: vine.string().optional(),
       username: vine.string().optional(),
-      githubId: vine.string().optional().requiredIfMissingAny(['email', 'username']),
+      githubId: vine.string().optional().requiredIfAnyMissing(['email', 'username']),
     })
 
     const data = {
@@ -244,7 +244,7 @@ test.group('requiredIfMissingAny', () => {
     const schema = vine.object({
       email: vine.string().optional(),
       username: vine.string().optional(),
-      githubId: vine.string().optional().requiredIfMissingAny(['email', 'username']),
+      githubId: vine.string().optional().requiredIfAnyMissing(['email', 'username']),
     })
 
     const data = {

--- a/tests/unit/rules/conditional_required.spec.ts
+++ b/tests/unit/rules/conditional_required.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * @vinejs/vine
+ *
+ * (c) VineJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { validator } from '../../../factories/main.js'
+import { requiredWhen } from '../../../src/schema/base/rules.js'
+
+test.group('Required when', () => {
+  test('report error when field is missing but required', () => {
+    const boolean = requiredWhen(() => {
+      return true
+    })
+    const validated = validator.execute(boolean, undefined)
+
+    validated.assertError('The dummy field must be defined')
+  })
+
+  test('report error when field is null but required', () => {
+    const boolean = requiredWhen(() => {
+      return true
+    })
+    const validated = validator.execute(boolean, null)
+
+    validated.assertError('The dummy field must be defined')
+  })
+
+  test('do not report error when field is missing but not required', () => {
+    const boolean = requiredWhen(() => {
+      return false
+    })
+    const validated = validator.execute(boolean, undefined)
+    validated.assertSucceeded()
+  })
+
+  test('do not report error when field is null but not required', () => {
+    const boolean = requiredWhen(() => {
+      return false
+    })
+    const validated = validator.execute(boolean, null)
+    validated.assertSucceeded()
+  })
+})

--- a/tests/unit/schema/string.spec.ts
+++ b/tests/unit/schema/string.spec.ts
@@ -364,7 +364,7 @@ test.group('VineString | clone', () => {
 
   test('apply nullable modifier and clone', ({ assert }) => {
     const schema = vine.string().nullable()
-    const schema1 = schema.clone().optional()
+    const schema1 = schema.clone().optional().requiredIfMissing('bar')
 
     assert.deepEqual(schema[PARSE]('*', refsBuilder(), { toCamelCase: false }), {
       type: 'literal',
@@ -396,13 +396,18 @@ test.group('VineString | clone', () => {
           isAsync: false,
           ruleFnId: 'ref://1',
         },
+        {
+          implicit: true,
+          isAsync: false,
+          ruleFnId: 'ref://2',
+        },
       ],
     })
   })
 
   test('apply optional modifier and clone', ({ assert }) => {
-    const schema = vine.string().optional()
-    const schema1 = schema.clone().nullable()
+    const schema = vine.string().optional().requiredIfMissing('bar')
+    const schema1 = schema.clone().requiredIfExists('foo').nullable()
 
     assert.deepEqual(schema[PARSE]('*', refsBuilder(), { toCamelCase: false }), {
       type: 'literal',
@@ -417,6 +422,11 @@ test.group('VineString | clone', () => {
           implicit: false,
           isAsync: false,
           ruleFnId: 'ref://1',
+        },
+        {
+          implicit: true,
+          isAsync: false,
+          ruleFnId: 'ref://2',
         },
       ],
     })
@@ -433,6 +443,16 @@ test.group('VineString | clone', () => {
           implicit: false,
           isAsync: false,
           ruleFnId: 'ref://1',
+        },
+        {
+          implicit: true,
+          isAsync: false,
+          ruleFnId: 'ref://2',
+        },
+        {
+          implicit: true,
+          isAsync: false,
+          ruleFnId: 'ref://3',
         },
       ],
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "@adonisjs/tsconfig/tsconfig.package.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./build",
-  },
+    "outDir": "./build"
+  }
 }


### PR DESCRIPTION
The `requiredIf` rules offer an alternate API to the `vine.union` which is less type-safe but also simpler to write and express conditions.

Here's a quick example between the `vine.union` and the `requiredIf` rules.

### With `vine.union`

```ts
const emailOrPhone = vine.group([
  vine.group.if((data) => 'email' in data, {
    email: vine.string().email()
  }),
  vine.group.if((data) => 'phone' in data, {
    phone: vine.string().mobile()
  }),
])

const loginForm = vine.object({
  password: vine
    .string()
    .minLength(6)
    .maxLength(32)
})
.merge(emailOrPhone)
```

The output type will be a union as well.

```ts
type LoginForm = {
  password: string
} & ({
  email: string
} | {
  phone: string
})
```

### With `requiredIfMissing`

```ts
const loginForm = vine.object({
  email: vine.string().email().optional().requiredIfMissing('phone'),
  phone: vine.string().mobile().optional().requiredIfMissing('email'),
  password: vine
    .string()
    .minLength(6)
    .maxLength(32)
})
```

The output will have both `email` and `phone` as optional even though one of them will be defined at runtime.

```ts
type LoginForm = {
  email: string | undefined,
  phone: string | undefined,
  password: string
})
```

The `requiredIfMissing` rules are helpful when you do not care much about the output data-types and you do not want to narrow them. For example, validate data and store it as a JSON blob in the database