### PR TITLE
fix: add "in" rule in default number rules (#44)

### DIFF
--- a/src/schema/number/main.ts
+++ b/src/schema/number/main.ts
@@ -34,6 +34,7 @@ export class VineNumber extends BaseLiteralType<string | number, number, number>
    * Default collection of number rules
    */
   static rules = {
+    in: inRule,
     max: maxRule,
     min: minRule,
     range: rangeRule,


### PR DESCRIPTION
### 🔗 Linked issue

#44

### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Resolves #44 and add `inRule`in default number rules as asked in #53

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly. (not in this PR, but on the PR I did for vinejs.dev)
