### PR TITLE
chore: export ObjectGroup and GroupConditional

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,8 @@ export { BaseLiteralType } from './src/schema/base/literal.js'
 export { BaseType, BaseModifiersType } from './src/schema/base/main.js'
 export { SimpleErrorReporter } from './src/reporters/simple_error_reporter.js'
 export { SimpleMessagesProvider } from './src/messages_provider/simple_messages_provider.js'
+export { ObjectGroup } from './src/schema/object/group.js'
+export { GroupConditional } from './src/schema/object/conditional.js'
 
 const vine = new Vine()
 export default vine


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey!

I'm working on a package to generate OpenAPI specs automatically based on the AST of AdonisJS apps. To do so, I need to augment the types of some VineJS methods (which is the case of the `merge` method of VineObject schema). But I couldn't do it, since `GroupObject` and `GroupConditional` are not exported to the userland.

This is the current type of the `merge` method:

```ts
merge<Group extends ObjectGroup<GroupConditional<any, any, any>>>(
    group: Group
  ): VineObject<
    Properties,
    Output & Group[typeof OTYPE],
    CamelCaseOutput & Group[typeof COTYPE]
  >
}
```

And this is what I'm trying to achieve:

```ts
merge<Group extends ObjectGroup<GroupConditional<any, any, any>>>(
    group: Group
  ): VineObject<
    Properties,
    Output & Group[typeof symbols.OTYPE],
    CamelCaseOutput & Group[typeof symbols.COTYPE]
  > &
    Group
}
```

As you can see, I need the two classes to access to `Group` type.

Is it possible to accept this PR, please?
