### PR TITLE
feat: add support to async transform functions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,11 @@ export type ValidationOptions<MetaData extends Record<string, any> | undefined> 
   messagesProvider?: MessagesProviderContact
 
   /**
+   * Control whether or not to await the result of async transformers
+   */
+  shouldAwaitTransformers?: boolean
+
+  /**
    * Validation errors are reported directly to an error reporter. The reporter
    * can decide how to format and output errors.
    */

--- a/src/vine/validator.ts
+++ b/src/vine/validator.ts
@@ -160,6 +160,23 @@ export class VineValidator<
   }
 
   /**
+   * Get all transformers for the schema
+   */
+  getFieldsNamesWithTransformers(): (keyof Infer<Schema>)[] {
+    const schema = this.#compiled.schema.schema
+
+    if (!('properties' in schema)) {
+      return []
+    }
+
+    const properties = schema.properties
+
+    return properties
+      .filter((property) => 'transformFnId' in property)
+      .map((property) => property.propertyName)
+  }
+
+  /**
    * Performs validation without throwing the validation
    * exception. Instead, the validation errors are
    * returned as the first argument.

--- a/tests/integration/schema/transform.spec.ts
+++ b/tests/integration/schema/transform.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * @vinejs/vine
+ *
+ * (c) VineJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import vine from '../../../index.js'
+
+test.group('Transform', () => {
+  const schema = vine.object({
+    name: vine.string().transform(async (value) => {
+      return `${value} | awaited`
+    }),
+  })
+
+  const data = { name: 'virk' }
+
+  test('pass when value is extracted from Promise', async ({ assert }) => {
+    const { name } = await vine.validate({ schema, data, shouldAwaitTransformers: true })
+    assert.equal(name, 'virk | awaited')
+  })
+
+  test('fail when value is not extracted from Promise', async ({ assert }) => {
+    const { name } = await vine.validate({ schema, data, shouldAwaitTransformers: false })
+    assert.isTrue(name instanceof Promise)
+  })
+})


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
[Issue #72 - async transform](https://github.com/vinejs/vine/issues/72)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Await all transform functions on `schema.validate` and `schema.tryValidate` calls;
Add a option to `ValidationOptions` called `shouldAwaitTransformers`, an `boolean` that indicates when the transformers should be awaited. Defaults to `undefined`.

[Resolves #72](https://github.com/vinejs/vine/issues/72)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. - [PR](https://github.com/vinejs/vinejs.dev/pull/24)