### PR TITLE
export UnionConditional to allow exporting validators using using vine.union.if

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ export { VineEnum } from './src/schema/enum/main.js'
 export { VineNativeEnum } from './src/schema/enum/native_enum.js'
 export { VineTuple } from './src/schema/tuple/main.js'
 export { VineUnion } from './src/schema/union/main.js'
+export { UnionConditional } from './src/schema/union/conditional.js';
 export { VineArray } from './src/schema/array/main.js'
 export { VineValidator } from './src/vine/validator.js'
 export { VineString } from './src/schema/string/main.js'


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When exporting a validator from a package using `vine.union.if` the compilation fails with error:

`- error TS2742: The inferred type of 'myValidator' cannot be named without a reference to '../../node_modules/@vinejs/vine/build/src/schema/union/conditional.js'. This is likely not por
│ table. A type annotation is necessary.`

Exporting UnionConditional fixes this issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
