### PR TITLE
add support UUID v6 v7 v8

### DIFF
--- a/src/schema/string/rules.ts
+++ b/src/schema/string/rules.ts
@@ -383,7 +383,7 @@ export const postalCodeRule = createRule<
 /**
  * Validates the value to be a valid UUID
  */
-export const uuidRule = createRule<{ version?: (1 | 2 | 3 | 4 | 5)[] } | undefined>(
+export const uuidRule = createRule<{ version?: (1 | 2 | 3 | 4 | 5 | 6 | 7 | 8)[] } | undefined>(
   function uuid(value, options, field) {
     if (!options || !options.version) {
       if (!helpers.isUUID(value as string)) {

--- a/tests/unit/rules/string.spec.ts
+++ b/tests/unit/rules/string.spec.ts
@@ -1287,6 +1287,22 @@ test.group('String | uuid', () => {
         rule: uuidRule({ version: [1, 4] }),
         value: '71e4fbab-3498-447b-a97c-2c6060069678',
       },
+      {
+        rule: uuidRule({ version: [6] }),
+        value: '1ec9414c-232a-6b00-b3c8-9e6bdeced846',
+      },
+      {
+        rule: uuidRule({ version: [7] }),
+        value: '017f22e2-79b0-7cc3-98c4-dc0c0c07398f',
+      },
+      {
+        rule: uuidRule({ version: [8] }),
+        value: '12345678-1234-8234-a234-123456789012',
+      },
+      {
+        rule: uuidRule({ version: [4, 6, 7, 8] }),
+        value: '71e4fbab-3498-447b-a97c-2c6060069678',
+      },
     ])
     .run(stringRuleValidator)
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

[Update related documentation](https://github.com/vinejs/vinejs.dev/pull/41)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since PostgreSQL v18 adds native support to work with UUID v7 and considering that `Validator` already supports [RFC9562 UUIDs](https://www.npmjs.com/package/validator#:~:text=string%20is%20an-,RFC9562,-UUID.%0Aversion), this pull request expands the `versions` type including the 6, 7, and 8 in the `uuidRule`. Also adds corresponding unit tests to ensure proper validation of these new UUID versions.

Validation rule updates:

* Updated the `uuidRule` in `src/schema/string/rules.ts` to accept UUID versions 6, 7, and 8, in addition to the previously supported versions.

Testing improvements:

* Added new unit tests in `tests/unit/rules/string.spec.ts` to verify validation for UUID versions 6, 7, and 8, as well as combinations of supported versions.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.