### PR TITLE
fix: optional date

### DIFF
--- a/src/schema/date/rules.ts
+++ b/src/schema/date/rules.ts
@@ -19,6 +19,10 @@ import type { DateEqualsOptions, DateFieldOptions, FieldContext } from '../../ty
  */
 export const dateRule = createRule<Partial<DateFieldOptions>>(
   function date(value, options, field): boolean {
+    if (!field.isDefined) {
+      return false
+    }
+
     if (typeof value !== 'string' && typeof value !== 'number') {
       field.report(messages.date, 'date', field)
       return false

--- a/tests/integration/schema/date.spec.ts
+++ b/tests/integration/schema/date.spec.ts
@@ -199,4 +199,33 @@ test.group('VineDate', () => {
     assert.equal(result.created_at.getMonth(), '3')
     assert.equal(result.created_at.getFullYear(), '2018')
   })
+
+  test('pass validation when optional date field is missing', async ({ assert }) => {
+    const schema = vine.object({
+      required_date: vine.date(),
+      optional_date: vine.date().optional(),
+    })
+
+    const data = { required_date: '2024-06-15' }
+    const result = await vine.validate({ schema, data })
+
+    assert.isTrue(result.required_date instanceof Date)
+    assert.isUndefined(result.optional_date)
+  })
+
+  test('pass validation when optional date field is provided', async ({ assert }) => {
+    const schema = vine.object({
+      required_date: vine.date(),
+      optional_date: vine.date().optional(),
+    })
+
+    const data = {
+      required_date: '2024-06-15',
+      optional_date: '2024-12-25',
+    }
+    const result = await vine.validate({ schema, data })
+
+    assert.isTrue(result.required_date instanceof Date)
+    assert.isTrue(result.optional_date instanceof Date)
+  })
 })


### PR DESCRIPTION
Bug introduced in v4.0.0

```ts
const test = vine.compile(
  vine.object({
    required_date: vine.date(),
    optional_date: vine.date().optional(),
  })
)

const result = await test.validate({ required_date: '2024-06-15' })
```

This code throws an error complaining that optional_date is missing, even though its marked as optional. This PR fixes that issue 