### PR TITLE
feat: add toOptional to object

### DIFF
--- a/src/schema/object/main.ts
+++ b/src/schema/object/main.ts
@@ -21,7 +21,16 @@ import {
   IS_OF_TYPE,
   type ITYPE,
 } from '../../symbols.js'
-import type { Validation, SchemaTypes, FieldOptions, ParserOptions } from '../../types.js'
+import type {
+  Validation,
+  SchemaTypes,
+  FieldOptions,
+  ParserOptions,
+  ObjectToOptional,
+  UndefinedOptional,
+  Id,
+} from '../../types.js'
+import { type CamelCase } from '../camelcase_types.ts'
 
 /**
  * Converts schema properties to camelCase during validation.
@@ -272,6 +281,52 @@ export class VineObject<
    */
   toCamelCase() {
     return new VineCamelCaseObject(this)
+  }
+
+  /**
+   * Creates a new object with all properties marked as optional.
+   */
+  toOptional(): VineObject<
+    ObjectToOptional<Properties>,
+    Partial<Input>,
+    Partial<Output>,
+    Partial<CamelCaseOutput>
+  >
+  toOptional<
+    Keys extends keyof Properties,
+    Props extends Record<string, SchemaTypes> = Omit<Properties, Keys> &
+      ObjectToOptional<Pick<Properties, Keys>>,
+  >(
+    keys: Keys[] | readonly Keys[]
+  ): VineObject<
+    Id<Props>,
+    UndefinedOptional<{
+      [K in keyof Props]: Props[K][typeof ITYPE]
+    }>,
+    UndefinedOptional<{
+      [K in keyof Props]: Props[K][typeof OTYPE]
+    }>,
+    UndefinedOptional<{
+      [K in keyof Props as CamelCase<K & string>]: Props[K][typeof COTYPE]
+    }>
+  >
+  toOptional<Keys extends keyof Properties>(keys?: Keys[] | readonly Keys[]) {
+    const properties: Record<string, SchemaTypes> = {}
+    for (const key of Object.keys(this.#properties)) {
+      let field = this.#properties[key].clone()
+
+      if (
+        (!keys || keys.includes(key as Keys)) &&
+        'optional' in field &&
+        typeof field.optional === 'function'
+      ) {
+        field = field.optional()
+      }
+
+      properties[key] = field
+    }
+
+    return new VineObject(properties)
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -819,3 +819,12 @@ export type UndefinedOptional<T> = Id<
     [K in PickNotUndefined<T>]: T[K]
   }
 >
+
+/**
+ * Utility type to convert object with schema properties to optional schemas.
+ *
+ * @template T - Record of property names to their schema types
+ */
+export type ObjectToOptional<T extends Record<string, SchemaTypes>> = Id<{
+  [K in keyof T]: T[K] extends { optional: () => infer R extends SchemaTypes } ? R : T[K]
+}>

--- a/src/vine/helpers.ts
+++ b/src/vine/helpers.ts
@@ -34,7 +34,13 @@ import { locales as mobilePhoneLocales } from 'validator/lib/isMobilePhone.js'
 // @ts-ignore type missing from @types/validator
 import { locales as postalCodeLocales } from 'validator/lib/isPostalCode.js'
 
-import type { DateEqualsOptions, DateFieldOptions, FieldContext } from '../types.js'
+import type {
+  DateEqualsOptions,
+  DateFieldOptions,
+  FieldContext,
+  ObjectToOptional,
+  SchemaTypes,
+} from '../types.js'
 
 /**
  * Values that are considered true in HTML form context.
@@ -693,5 +699,27 @@ export const helpers = {
       return delve(field.data, key)
     }
     return field.parent[key]
+  },
+
+  /**
+   * Converts all properties of an object schema to optional.
+   *
+   * @param props - The object with schema properties
+   * @returns New object with all properties marked as optional
+   */
+  optional<Props extends Record<string, SchemaTypes>>(props: Props): ObjectToOptional<Props> {
+    const result: Record<string, SchemaTypes> = {}
+
+    for (const name of Object.keys(props)) {
+      let field = props[name].clone()
+
+      if ('optional' in field && typeof field.optional === 'function') {
+        field = field.optional()
+      }
+
+      result[name] = field
+    }
+
+    return result as ObjectToOptional<Props>
   },
 }

--- a/tests/unit/schema/object.spec.ts
+++ b/tests/unit/schema/object.spec.ts
@@ -3887,4 +3887,165 @@ test.group('VineObject | clone', () => {
       ],
     })
   })
+
+  test('convert to all properties optional', ({ assert }) => {
+    const refs = refsBuilder()
+
+    const schema = vine
+      .object({
+        username: vine.string(),
+        password: vine.string(),
+        is_remember: vine.boolean(),
+        optional: vine.string().optional(),
+        nested: vine.object({
+          prop: vine.string(),
+        }),
+      })
+      .toOptional()
+
+    assert.deepEqual(schema[PARSE]('*', refs, { toCamelCase: false }), {
+      type: 'object',
+      fieldName: '*',
+      propertyName: '*',
+      bail: true,
+      allowNull: false,
+      isOptional: false,
+      allowUnknownProperties: false,
+      validations: [],
+      groups: [],
+      parseFnId: undefined,
+      properties: [
+        {
+          type: 'literal',
+          subtype: 'string',
+          fieldName: 'username',
+          propertyName: 'username',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          dataTypeValidatorFnId: 'ref://1',
+          validations: [],
+          parseFnId: undefined,
+        },
+        {
+          type: 'literal',
+          subtype: 'string',
+          fieldName: 'password',
+          propertyName: 'password',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          dataTypeValidatorFnId: 'ref://2',
+          validations: [],
+          parseFnId: undefined,
+        },
+        {
+          type: 'literal',
+          subtype: 'boolean',
+          fieldName: 'is_remember',
+          propertyName: 'is_remember',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          validations: [
+            {
+              implicit: false,
+              isAsync: false,
+              name: 'boolean',
+              ruleFnId: 'ref://3',
+            },
+          ],
+          parseFnId: undefined,
+        },
+        {
+          type: 'literal',
+          subtype: 'string',
+          fieldName: 'optional',
+          propertyName: 'optional',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          dataTypeValidatorFnId: 'ref://4',
+          validations: [],
+          parseFnId: undefined,
+        },
+        {
+          type: 'object',
+          fieldName: 'nested',
+          propertyName: 'nested',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          allowUnknownProperties: false,
+          validations: [],
+          groups: [],
+          parseFnId: undefined,
+          properties: [
+            {
+              type: 'literal',
+              subtype: 'string',
+              fieldName: 'prop',
+              propertyName: 'prop',
+              bail: true,
+              allowNull: false,
+              isOptional: false,
+              dataTypeValidatorFnId: 'ref://5',
+              validations: [],
+              parseFnId: undefined,
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test('convert to some properties optional', ({ assert }) => {
+    const refs = refsBuilder()
+
+    const schema = vine
+      .object({
+        username: vine.string(),
+        password: vine.string(),
+      })
+      .toOptional(['username'])
+
+    assert.deepEqual(schema[PARSE]('*', refs, { toCamelCase: false }), {
+      type: 'object',
+      fieldName: '*',
+      propertyName: '*',
+      bail: true,
+      allowNull: false,
+      isOptional: false,
+      allowUnknownProperties: false,
+      validations: [],
+      groups: [],
+      parseFnId: undefined,
+      properties: [
+        {
+          type: 'literal',
+          subtype: 'string',
+          fieldName: 'username',
+          propertyName: 'username',
+          bail: true,
+          allowNull: false,
+          isOptional: true,
+          dataTypeValidatorFnId: 'ref://1',
+          validations: [],
+          parseFnId: undefined,
+        },
+        {
+          type: 'literal',
+          subtype: 'string',
+          fieldName: 'password',
+          propertyName: 'password',
+          bail: true,
+          allowNull: false,
+          isOptional: false,
+          dataTypeValidatorFnId: 'ref://2',
+          validations: [],
+          parseFnId: undefined,
+        },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

It's common use case to have a schema for create (POST) method and then the same schema for update (PATCH), but with all properties as optional.

With this PR it's possible to convert object to all properties optional easily.

```ts
const postSchema = vine.object({
  title: vine.string(),
  content: vine.string(),
})

export const createPostValidator = vine.compile({
  ...postSchema.getProperties(),
  isPublished: vine.boolean().optional(),
})

export const updatePostValidator = vine.compile(postSchema.toOptional())
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
