### PR TITLE
feat(rules): add `phone` rule with country specific option

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "camelcase": "^8.0.0",
     "dayjs": "^1.11.18",
     "dlv": "^1.1.3",
+    "libphonenumber-js": "^1.12.26",
     "normalize-url": "^8.1.0",
     "validator": "^13.15.15"
   },

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -37,6 +37,7 @@ export const messages = {
   'string': 'The {{ field }} field must be a string',
   'email': 'The {{ field }} field must be a valid email address',
   'mobile': 'The {{ field }} field must be a valid mobile phone number',
+  'phone': 'The {{ field }} field must be a valid phone number',
   'creditCard': 'The {{ field }} field must be a valid {{ providersList }} card number',
   'passport': 'The {{ field }} field must be a valid passport number',
   'postalCode': 'The {{ field }} field must be a valid postal code',

--- a/src/schema/string/main.ts
+++ b/src/schema/string/main.ts
@@ -32,6 +32,7 @@ import {
   asciiRule,
   regexRule,
   sameAsRule,
+  phoneRule,
   mobileRule,
   escapeRule,
   stringRule,
@@ -92,6 +93,7 @@ export class VineString extends BaseLiteralType<string, string, string> {
     regex: regexRule,
     escape: escapeRule,
     sameAs: sameAsRule,
+    phone: phoneRule,
     mobile: mobileRule,
     string: stringRule,
     hexCode: hexCodeRule,
@@ -185,6 +187,13 @@ export class VineString extends BaseLiteralType<string, string, string> {
   }
 
   /**
+   * Validates the value to be a valid phone number.
+   */
+  phone(...args: Parameters<typeof phoneRule>) {
+    return this.use(phoneRule(...args))
+  }
+
+  /**
    * Validates the value to be a valid IP address.
    */
   ipAddress(version?: 4 | 6) {
@@ -257,15 +266,15 @@ export class VineString extends BaseLiteralType<string, string, string> {
   confirmed(
     options?:
       | {
-          /**
-           * @deprecated
-           * Use "as" field instead
-           */
-          confirmationField?: string
-        }
+        /**
+         * @deprecated
+         * Use "as" field instead
+         */
+        confirmationField?: string
+      }
       | {
-          as?: string
-        }
+        as?: string
+      }
   ) {
     return this.use(confirmedRule(options))
   }

--- a/src/schema/string/main.ts
+++ b/src/schema/string/main.ts
@@ -266,15 +266,15 @@ export class VineString extends BaseLiteralType<string, string, string> {
   confirmed(
     options?:
       | {
-        /**
-         * @deprecated
-         * Use "as" field instead
-         */
-        confirmationField?: string
-      }
+          /**
+           * @deprecated
+           * Use "as" field instead
+           */
+          confirmationField?: string
+        }
       | {
-        as?: string
-      }
+          as?: string
+        }
   ) {
     return this.use(confirmedRule(options))
   }

--- a/src/schema/string/rules.ts
+++ b/src/schema/string/rules.ts
@@ -18,6 +18,7 @@ import { helpers } from '../../vine/helpers.js'
 import { createRule } from '../../vine/create_rule.js'
 import type {
   URLOptions,
+  PhoneOptions,
   AlphaOptions,
   EmailOptions,
   MobileOptions,
@@ -67,6 +68,20 @@ export const mobileRule = createRule<
 
   if (!helpers.isMobilePhone(value as string, locales, normalizedOptions)) {
     field.report(messages.mobile, 'mobile', field)
+  }
+})
+
+/**
+ * Validates the value to be a valid phone number.
+ */
+export const phoneRule = createRule<
+  PhoneOptions | undefined | ((field: FieldContext) => PhoneOptions | undefined)
+>(function phone(value, options, field) {
+  const normalizedOptions = options && typeof options === 'function' ? options(field) : options
+  const countryCode = normalizedOptions?.countryCode
+
+  if (!helpers.isPhone(value as string, countryCode)) {
+    field.report(messages.phone, 'phone', field)
   }
 })
 
@@ -258,15 +273,15 @@ export const notSameAsRule = createRule<{ otherField: string }>(
  */
 export const confirmedRule = createRule<
   | {
-      /**
-       * @deprecated
-       * Use "as" field instead
-       */
-      confirmationField?: string
-    }
+    /**
+     * @deprecated
+     * Use "as" field instead
+     */
+    confirmationField?: string
+  }
   | {
-      as?: string
-    }
+    as?: string
+  }
   | undefined
 >(function confirmed(value, options, field) {
   const normalizedOptions: { confirmationField?: string; as?: string } = options ?? {}

--- a/src/schema/string/rules.ts
+++ b/src/schema/string/rules.ts
@@ -273,15 +273,15 @@ export const notSameAsRule = createRule<{ otherField: string }>(
  */
 export const confirmedRule = createRule<
   | {
-    /**
-     * @deprecated
-     * Use "as" field instead
-     */
-    confirmationField?: string
-  }
+      /**
+       * @deprecated
+       * Use "as" field instead
+       */
+      confirmationField?: string
+    }
   | {
-    as?: string
-  }
+      as?: string
+    }
   | undefined
 >(function confirmed(value, options, field) {
   const normalizedOptions: { confirmationField?: string; as?: string } = options ?? {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,7 +260,7 @@ export type {
  * }
  * // Status satisfies EnumLike
  */
-export type EnumLike = { [K: string]: string | number;[number: number]: string }
+export type EnumLike = { [K: string]: string | number; [number: number]: string }
 
 /**
  * Representation of validation error messages accepted by the messages provider.
@@ -731,13 +731,13 @@ export type ValidationOptions<MetaData extends Record<string, any> | undefined> 
   errorReporter?: () => ErrorReporterContract
 } & ([undefined] extends MetaData
   ? {
-    /** Optional metadata to pass to validators for additional context */
-    meta?: MetaData
-  }
+      /** Optional metadata to pass to validators for additional context */
+      meta?: MetaData
+    }
   : {
-    /** Required metadata to pass to validators for additional context */
-    meta: MetaData
-  })
+      /** Required metadata to pass to validators for additional context */
+      meta: MetaData
+    })
 
 /**
  * Utility type to infer the output type of a schema.

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import type { IsEmailOptions } from 'validator/lib/isEmail.js'
 import type { PostalCodeLocale } from 'validator/lib/isPostalCode.js'
 import type { NormalizeEmailOptions } from 'validator/lib/normalizeEmail.js'
 import type { IsMobilePhoneOptions, MobilePhoneLocale } from 'validator/lib/isMobilePhone.js'
+import type { CountryCode } from 'libphonenumber-js'
 import type {
   ParseFn,
   RefsStore,
@@ -117,6 +118,27 @@ export { NormalizeEmailOptions }
  * }
  */
 export type URLOptions = IsURLOptions
+
+/**
+ * Options accepted by the phone number validation rule.
+ * Configures phone number validation behavior.
+ *
+ * Unlike mobile validation which is locale-based, phone validation
+ * uses international phone number standards with optional country context.
+ *
+ * @example
+ * const options: PhoneOptions = {
+ *   countryCode: 'US'
+ * }
+ */
+export type PhoneOptions = {
+  /**
+   * ISO 3166-1 alpha-2 country code for default country when validating national numbers.
+   * When provided, allows validation of national format numbers in addition to international format.
+   * If not provided, only international format (+prefix) numbers are accepted.
+   */
+  countryCode?: CountryCode
+}
 
 /**
  * Options accepted by the credit card validation rule.
@@ -238,7 +260,7 @@ export type {
  * }
  * // Status satisfies EnumLike
  */
-export type EnumLike = { [K: string]: string | number; [number: number]: string }
+export type EnumLike = { [K: string]: string | number;[number: number]: string }
 
 /**
  * Representation of validation error messages accepted by the messages provider.
@@ -709,13 +731,13 @@ export type ValidationOptions<MetaData extends Record<string, any> | undefined> 
   errorReporter?: () => ErrorReporterContract
 } & ([undefined] extends MetaData
   ? {
-      /** Optional metadata to pass to validators for additional context */
-      meta?: MetaData
-    }
+    /** Optional metadata to pass to validators for additional context */
+    meta?: MetaData
+  }
   : {
-      /** Required metadata to pass to validators for additional context */
-      meta: MetaData
-    })
+    /** Required metadata to pass to validators for additional context */
+    meta: MetaData
+  })
 
 /**
  * Utility type to infer the output type of a schema.

--- a/src/vine/helpers.ts
+++ b/src/vine/helpers.ts
@@ -29,6 +29,7 @@ import isPassportNumber from 'validator/lib/isPassportNumber.js'
 import customParseFormat from 'dayjs/plugin/customParseFormat.js'
 import isPostalCode, { type PostalCodeLocale } from 'validator/lib/isPostalCode.js'
 import isMobilePhone, { type MobilePhoneLocale } from 'validator/lib/isMobilePhone.js'
+import { parsePhoneNumberFromString, type CountryCode } from 'libphonenumber-js'
 // @ts-ignore type missing from @types/validator
 import { locales as mobilePhoneLocales } from 'validator/lib/isMobilePhone.js'
 // @ts-ignore type missing from @types/validator
@@ -453,6 +454,26 @@ export const helpers = {
   isSlug: isSlug.default,
   /** Validates decimal numbers */
   isDecimal: isDecimal.default,
+
+  /**
+   * Validates phone numbers.
+   * Supports international format validation and country-specific validation.
+   *
+   * @param value - The phone number string to validate
+   * @param countryCode - Optional ISO 3166-1 alpha-2 country code for validation context
+   * @returns True if the phone number is valid according to international standards
+   *
+   * @example
+   * helpers.isPhone('+14155551234') // true (US international format)
+   * helpers.isPhone('+33123456789') // true (French international format)
+   * helpers.isPhone('0123456789', 'FR') // true (French national format)
+   * helpers.isPhone('123', 'US') // false (invalid format)
+   */
+  isPhone(value: string, countryCode?: CountryCode): boolean {
+    const phoneNumber = parsePhoneNumberFromString(value, countryCode)
+    return phoneNumber?.isValid() ?? false
+  },
+
   /** Array of supported mobile phone locales/countries */
   mobileLocales: mobilePhoneLocales as MobilePhoneLocale[],
   /** Array of supported postal code country codes */

--- a/tests/unit/rules/string.spec.ts
+++ b/tests/unit/rules/string.spec.ts
@@ -16,6 +16,7 @@ import {
   alphaRule,
   emailRule,
   stringRule,
+  phoneRule,
   mobileRule,
   hexCodeRule,
   endsWithRule,
@@ -212,6 +213,98 @@ test.group('String | mobile', () => {
           return {}
         }),
         value: '9883443344',
+      },
+    ])
+    .run(stringRuleValidator)
+})
+
+test.group('String | phone', () => {
+  test('validate {value}')
+    .with([
+      {
+        errorsCount: 1,
+        rule: phoneRule(),
+        value: 22,
+        error: 'The dummy field must be a string',
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule(),
+        value: 22,
+        bail: false,
+        error: 'The dummy field must be a string',
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule(),
+        value: '123',
+        error: 'The dummy field must be a valid phone number',
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule(),
+        value: 'not a phone',
+        error: 'The dummy field must be a valid phone number',
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule(),
+        value: '123-abc-456',
+        error: 'The dummy field must be a valid phone number',
+      },
+      {
+        rule: phoneRule(),
+        value: '+33123456789',
+      },
+      {
+        rule: phoneRule(),
+        value: '+12125551234', // Valid NYC number instead of +1234567890
+      },
+      {
+        rule: phoneRule(),
+        value: '+447911123456',
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule({ countryCode: 'US' }),
+        value: '123',
+        error: 'The dummy field must be a valid phone number',
+      },
+      {
+        rule: phoneRule({ countryCode: 'US' }),
+        value: '(212) 555-1234', // Valid NYC number instead of (555) 123-4567
+      },
+      {
+        rule: phoneRule({ countryCode: 'US' }),
+        value: '212-555-1234', // Valid NYC number instead of 555-123-4567
+      },
+      {
+        rule: phoneRule({ countryCode: 'US' }),
+        value: '2125551234', // Valid NYC number instead of 5551234567
+      },
+      {
+        rule: phoneRule({ countryCode: 'FR' }),
+        value: '0123456789',
+      },
+      {
+        rule: phoneRule(() => {
+          return { countryCode: 'US' }
+        }),
+        value: '(212) 555-1234', // Valid NYC number instead of (555) 123-4567
+      },
+      {
+        errorsCount: 1,
+        rule: phoneRule(() => {
+          return { countryCode: 'US' }
+        }),
+        value: '123',
+        error: 'The dummy field must be a valid phone number',
+      },
+      {
+        rule: phoneRule(() => {
+          return {}
+        }),
+        value: '+14155551234', // Valid San Francisco number instead of +1234567890
       },
     ])
     .run(stringRuleValidator)


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue or discussion.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces a new `phone` validation rule for VineJS that provides comprehensive phone number validation using the [`libphonenumber-js`](https://www.npmjs.com/package/libphonenumber-js) library. This library validates both mobile and landline numbers in any format, supports all countries, and accepts user-friendly input styles. This reduces false negatives and improves global compatibility, while the `mobile` rule is limited to strict mobile patterns for specific locales.

```javascript
// International format validation
vine.string().phone()

// Country-specific format validation
vine.string().phone({ countryCode: 'US' })

// Dynamic format validation
vine.string().phone(() => ({ countryCode: 'US' }))
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.