### PR TITLE
fix: object toOptional types

### DIFF
--- a/src/schema/object/main.ts
+++ b/src/schema/object/main.ts
@@ -26,11 +26,11 @@ import type {
   SchemaTypes,
   FieldOptions,
   ParserOptions,
-  ObjectToOptional,
-  UndefinedOptional,
+  PropertiesToOptional,
   Id,
+  UndefinedOptional,
 } from '../../types.js'
-import { type CamelCase } from '../camelcase_types.ts'
+import type { CamelCase } from '../camelcase_types.ts'
 
 /**
  * Converts schema properties to camelCase during validation.
@@ -286,31 +286,31 @@ export class VineObject<
   /**
    * Creates a new object with all properties marked as optional.
    */
-  toOptional(): VineObject<
-    ObjectToOptional<Properties>,
-    Partial<Input>,
-    Partial<Output>,
-    Partial<CamelCaseOutput>
-  >
   toOptional<
-    Keys extends keyof Properties,
-    Props extends Record<string, SchemaTypes> = Omit<Properties, Keys> &
-      ObjectToOptional<Pick<Properties, Keys>>,
+    Keys extends keyof Properties = keyof Properties,
+    T extends Record<string, SchemaTypes> = Omit<Properties, Keys> &
+      PropertiesToOptional<Pick<Properties, Keys>>,
   >(
-    keys: Keys[] | readonly Keys[]
+    keys?: Keys[] | readonly Keys[]
   ): VineObject<
-    Id<Props>,
+    Id<T>,
     UndefinedOptional<{
-      [K in keyof Props]: Props[K][typeof ITYPE]
+      [K in keyof T]: T[K][typeof ITYPE]
     }>,
     UndefinedOptional<{
-      [K in keyof Props]: Props[K][typeof OTYPE]
+      [K in keyof T]: T[K][typeof OTYPE]
     }>,
     UndefinedOptional<{
-      [K in keyof Props as CamelCase<K & string>]: Props[K][typeof COTYPE]
+      [K in keyof T as CamelCase<K & string>]: T[K][typeof COTYPE]
     }>
-  >
-  toOptional<Keys extends keyof Properties>(keys?: Keys[] | readonly Keys[]) {
+  > {
+    // groups and allowUnknownProperties are not allowed for complexity reasons
+    if (this.#groups.length > 0 || this.#allowUnknownProperties) {
+      throw new Error(
+        'toOptional cannot be used on schemas that have groups or allowUnknownProperties enabled'
+      )
+    }
+
     const properties: Record<string, SchemaTypes> = {}
     for (const key of Object.keys(this.#properties)) {
       let field = this.#properties[key].clone()
@@ -326,7 +326,18 @@ export class VineObject<
       properties[key] = field
     }
 
-    return new VineObject(properties)
+    return new VineObject(properties, this.cloneOptions(), this.cloneValidations()) as VineObject<
+      Id<T>,
+      UndefinedOptional<{
+        [K in keyof T]: T[K][typeof ITYPE]
+      }>,
+      UndefinedOptional<{
+        [K in keyof T]: T[K][typeof OTYPE]
+      }>,
+      UndefinedOptional<{
+        [K in keyof T as CamelCase<K & string>]: T[K][typeof COTYPE]
+      }>
+    >
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -825,6 +825,6 @@ export type UndefinedOptional<T> = Id<
  *
  * @template T - Record of property names to their schema types
  */
-export type ObjectToOptional<T extends Record<string, SchemaTypes>> = Id<{
+export type PropertiesToOptional<T extends Record<string, SchemaTypes>> = Id<{
   [K in keyof T]: T[K] extends { optional: () => infer R extends SchemaTypes } ? R : T[K]
 }>

--- a/src/vine/helpers.ts
+++ b/src/vine/helpers.ts
@@ -38,7 +38,7 @@ import type {
   DateEqualsOptions,
   DateFieldOptions,
   FieldContext,
-  ObjectToOptional,
+  PropertiesToOptional,
   SchemaTypes,
 } from '../types.js'
 
@@ -707,7 +707,7 @@ export const helpers = {
    * @param props - The object with schema properties
    * @returns New object with all properties marked as optional
    */
-  optional<Props extends Record<string, SchemaTypes>>(props: Props): ObjectToOptional<Props> {
+  optional<Props extends Record<string, SchemaTypes>>(props: Props): PropertiesToOptional<Props> {
     const result: Record<string, SchemaTypes> = {}
 
     for (const name of Object.keys(props)) {
@@ -720,6 +720,6 @@ export const helpers = {
       result[name] = field
     }
 
-    return result as ObjectToOptional<Props>
+    return result as PropertiesToOptional<Props>
   },
 }

--- a/tests/unit/schema/object.spec.ts
+++ b/tests/unit/schema/object.spec.ts
@@ -4048,4 +4048,26 @@ test.group('VineObject | clone', () => {
       ],
     })
   })
+
+  test('toOptional throws error for groups and unknown properties', () => {
+    const guideSchema = vine.group([
+      vine.group.if((data) => vine.helpers.isTrue(data.hiring_guide), {
+        hiring_guide: vine.literal(true),
+        guide_name: vine.string(),
+        fees: vine.string(),
+      }),
+      vine.group.if(() => true, {
+        hiring_guide: vine.literal(false),
+      }),
+    ])
+
+    vine
+      .object({
+        visitor_name: vine.string(),
+      })
+      .merge(guideSchema)
+      .toOptional()
+  }).throws(
+    'toOptional cannot be used on schemas that have groups or allowUnknownProperties enabled'
+  )
 })


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes types when using `vine.object().toOptional()` together with groups.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
