### PR TITLE
feat(rules): add `strongPassword` rule

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -64,6 +64,7 @@ export const messages = {
   'uuid': 'The {{ field }} field must be a valid UUID',
   'ulid': 'The {{ field }} field must be a valid ULID',
   'hexCode': 'The {{ field }} field must be a valid hex color code',
+  'strongPassword': 'The {{ field }} field must be a strong password',
 
   'boolean': 'The value must be a boolean',
 

--- a/src/schema/string/main.ts
+++ b/src/schema/string/main.ts
@@ -56,6 +56,7 @@ import {
   alphaNumericRule,
   normalizeEmailRule,
   vatRule,
+  strongPasswordRule,
 } from './rules.js'
 
 /**
@@ -103,6 +104,7 @@ export class VineString extends BaseLiteralType<string, string, string> {
     minLength: minLengthRule,
     notSameAs: notSameAsRule,
     maxLength: maxLengthRule,
+    strongPassword: strongPasswordRule,
     vat: vatRule,
     ipAddress: ipAddressRule,
     creditCard: creditCardRule,
@@ -191,6 +193,13 @@ export class VineString extends BaseLiteralType<string, string, string> {
    */
   vat(...args: Parameters<typeof vatRule>) {
     return this.use(vatRule(...args))
+  }
+
+  /**
+   * Validates the value to be a strong password.
+   */
+  strongPassword(...args: Parameters<typeof strongPasswordRule>) {
+    return this.use(strongPasswordRule(...args))
   }
 
   /**

--- a/src/schema/string/rules.ts
+++ b/src/schema/string/rules.ts
@@ -28,6 +28,7 @@ import type {
   AlphaNumericOptions,
   NormalizeEmailOptions,
   VATOptions,
+  StrongPasswordOptions,
 } from '../../types.js'
 
 /**
@@ -363,6 +364,19 @@ export const creditCardRule = createRule<
         providersList: providers.join('/'),
       })
     }
+  }
+})
+
+/**
+ * Validates the value to be a strong password.
+ */
+export const strongPasswordRule = createRule<
+  StrongPasswordOptions | undefined | ((field: FieldContext) => StrongPasswordOptions | undefined)
+>(function strongPassword(value, options, field) {
+  const normalizedOptions = typeof options === 'function' ? options(field) : options
+
+  if (!helpers.isStrongPassword(value as string, normalizedOptions)) {
+    field.report(messages.strongPassword, 'strongPassword', field)
   }
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ import type { IsURLOptions } from 'validator/lib/isURL.js'
 import type { IsEmailOptions } from 'validator/lib/isEmail.js'
 import type { PostalCodeLocale } from 'validator/lib/isPostalCode.js'
 import type { VATCountryCode } from 'validator/lib/isVAT.js'
+import type { StrongPasswordOptions } from 'validator/lib/isStrongPassword.js'
 import type { NormalizeEmailOptions } from 'validator/lib/normalizeEmail.js'
 import type { IsMobilePhoneOptions, MobilePhoneLocale } from 'validator/lib/isMobilePhone.js'
 import type {
@@ -91,6 +92,22 @@ export type Literal = string | number | bigint | boolean | null | undefined
  * }
  */
 export type EmailOptions = IsEmailOptions
+
+/**
+ * Options accepted by the strong password validation rule.
+ * Configures the criteria for what constitutes a strong password,
+ * including length requirements and character type inclusion.
+ *
+ * @example
+ * const options: StrongPasswordOptions = {
+ *   minLength: 8,
+ *   minLowercase: 1,
+ *   minUppercase: 1,
+ *   minNumbers: 1,
+ *   minSymbols: 1
+ * }
+ */
+export { StrongPasswordOptions }
 
 /**
  * Options accepted by the normalize email transformation.

--- a/src/vine/helpers.ts
+++ b/src/vine/helpers.ts
@@ -25,6 +25,7 @@ import isCreditCard from 'validator/lib/isCreditCard.js'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js'
 import isAlphanumeric from 'validator/lib/isAlphanumeric.js'
+import isStrongPassword from 'validator/lib/isStrongPassword.js'
 import isPassportNumber from 'validator/lib/isPassportNumber.js'
 import isVAT from 'validator/lib/isVAT.js'
 import customParseFormat from 'dayjs/plugin/customParseFormat.js'
@@ -444,6 +445,8 @@ export const helpers = {
   isJWT: isJWT.default,
   /** Validates latitude/longitude coordinate pairs */
   isLatLong: isLatLong.default,
+  /** Validates strong password criteria */
+  isStrongPassword: isStrongPassword.default,
   /** Validates mobile phone numbers for various locales */
   isMobilePhone: isMobilePhone.default,
   /** Validates passport numbers for supported countries */

--- a/tests/unit/rules/string.spec.ts
+++ b/tests/unit/rules/string.spec.ts
@@ -47,6 +47,7 @@ import {
   escapeRule,
   normalizeUrlRule,
   vatRule,
+  strongPasswordRule,
 } from '../../../src/schema/string/rules.ts'
 import type { FieldContext, Validation } from '../../../src/types.ts'
 
@@ -1698,6 +1699,97 @@ test.group('String | vat', () => {
         }),
         value: 'DE136695976',
         error: 'The dummy field must be a valid VAT number',
+      },
+    ])
+    .run(stringRuleValidator)
+})
+
+test.group('String | strongPassword', () => {
+  test('validate {value}')
+    .with([
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule(),
+        value: 22,
+        error: 'The dummy field must be a string',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule(),
+        value: 'weak',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule(),
+        value: 'StrongP@ss1',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule(),
+        value: 'MyP@ssw0rd!',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule({ minLength: 12 }),
+        value: 'Short@1',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule({ minLength: 12 }),
+        value: 'LongP@ssw0rd!',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule({ minLowercase: 2 }),
+        value: 'PASSWORD1!',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule({ minLowercase: 2 }),
+        value: 'PASSword1!',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule({ minUppercase: 2 }),
+        value: 'Password1!',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule({ minUppercase: 2 }),
+        value: 'PAssword1!',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule({ minNumbers: 2 }),
+        value: 'Password1!',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule({ minNumbers: 2 }),
+        value: 'Password12!',
+      },
+      {
+        errorsCount: 1,
+        rule: strongPasswordRule({ minSymbols: 2 }),
+        value: 'Password1!',
+        error: 'The dummy field must be a strong password',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule({ minSymbols: 2 }),
+        value: 'Password1!@',
+      },
+      {
+        errorsCount: 0,
+        rule: strongPasswordRule(() => {
+          return { minLength: 10, minUppercase: 1, minLowercase: 1, minNumbers: 1, minSymbols: 1 }
+        }),
+        value: 'MyP@ssw0rd',
       },
     ])
     .run(stringRuleValidator)

--- a/tests/unit/schema/string.spec.ts
+++ b/tests/unit/schema/string.spec.ts
@@ -50,6 +50,7 @@ import {
   normalizeUrlRule,
   mobileRule,
   vatRule,
+  strongPasswordRule,
 } from '../../../src/schema/string/rules.ts'
 
 const vine = new Vine()
@@ -686,6 +687,11 @@ test.group('VineString | applying rules', () => {
         name: 'vat',
         schema: vine.string().vat({ countryCode: ['IN'] }),
         rule: vatRule({ countryCode: ['IN'] }),
+      },
+      {
+        name: 'strongPassword',
+        schema: vine.string().strongPassword(),
+        rule: strongPasswordRule(),
       },
     ])
     .run(({ assert }, { schema, rule }) => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue or discussion.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces a new `strongPassword` validation rule for string schemas in VineJS, based on the [`validator`](https://www.npmjs.com/package/validator) library. No external library is added, so the core package size remains small.

```javascript
// Default strong password (8+ chars, lowercase, uppercase, number and symbol)
vine.string().strongPassword()

// Strict strong password (12+ chars, 2 lowercase, 2 uppercase, 2 numbers and symbol)
vine.string().strongPassword({
  minLength: 12,
  minLowercase: 2,
  minUppercase: 2,
  minNumbers: 2,
  minSymbols: 1
})

// Strong password without special characters (10+ chars, lowercase, uppercase and number)
vine.string().strongPassword({
  minLength: 10,
  minLowercase: 1,
  minUppercase: 1,
  minNumbers: 1,
  minSymbols: 0
})
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.