### PR TITLE
feat: add StandardJSONSchema support

### DIFF
--- a/src/vine/validator.ts
+++ b/src/vine/validator.ts
@@ -8,7 +8,7 @@
  */
 
 import { Compiler, refsBuilder } from '@vinejs/compiler'
-import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from '@standard-schema/spec'
 import type { MessagesProviderContact, Refs, RootNode } from '@vinejs/compiler/types'
 
 import { messages } from '../defaults.js'
@@ -254,9 +254,20 @@ export class VineValidator<
     return this.#jsonSchema
   }
 
-  readonly '~standard': StandardSchemaV1.Props<Schema[typeof ITYPE], Schema[typeof OTYPE]> = {
+  readonly '~standard': StandardSchemaV1.Props<Schema[typeof ITYPE], Schema[typeof OTYPE]> &
+    StandardJSONSchemaV1.Props<Schema[typeof ITYPE], Schema[typeof OTYPE]> = {
     version: 1,
     vendor: 'vinejs',
+
+    jsonSchema: {
+      input: () => {
+        return this.toJSONSchema() as Record<string, unknown>
+      },
+      output: () => {
+        throw new Error('Vine.js does not support creating validators using JSON Schema.')
+      },
+    },
+
     validate: async (data: unknown) => {
       const [error, result] = await this.tryValidate(data, {} as any)
       if (result) {

--- a/tests/integration/json_schema.spec.ts
+++ b/tests/integration/json_schema.spec.ts
@@ -3,6 +3,7 @@ import vine from '../../index.js'
 import Ajv from 'ajv'
 import { type SchemaTypes } from '../../src/types.js'
 import { inspect } from 'node:util'
+import { type StandardJSONSchemaV1 } from '@standard-schema/spec'
 
 const ajv = new Ajv()
 
@@ -668,4 +669,43 @@ test.group('JsonSchema', () => {
       }
     })
     .tags(['@literal'])
+})
+
+test.group('JsonSchema | StandardJsonSchema', () => {
+  test('should respect StandardJSONSchemaV1 type', ({ expectTypeOf }) => {
+    const validator = vine.create({
+      name: vine.string(),
+      email: vine.string().email(),
+    })
+
+    expectTypeOf<StandardJSONSchemaV1>(validator)
+  })
+
+  test('convert to json-schema as per standard schema spec', ({ assert }) => {
+    const validator = vine.create({
+      name: vine.string(),
+      email: vine.string().email(),
+    })
+
+    const result = validator['~standard'].jsonSchema.input({ target: 'draft-2020-12' })
+
+    assert.deepEqual(result, {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        email: { type: 'string', format: 'email' },
+      },
+      additionalProperties: false,
+      required: ['name', 'email'],
+    })
+  })
+
+  test('convert from json-schema as per standard schema spec should throw', ({ assert }) => {
+    const validator = vine.create({
+      name: vine.string(),
+      email: vine.string().email(),
+    })
+
+    assert.throws(() => validator['~standard'].jsonSchema.output({ target: 'draft-2020-12' }))
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This feature is a follow-up of the [json-schema support implementation](https://github.com/vinejs/vine/pull/118). It implements the `StandardJSONSchemaV1` type.

For now we do not support different json-schema draft versions nor options so conversion behave the same regarding the provided options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
