### PR TITLE
chore: bump tsdown version to fix node:module static import

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "luxon": "^3.7.2",
     "prettier": "^3.8.1",
     "release-it": "^19.2.4",
-    "tsdown": "^0.20.3",
+    "tsdown": "^0.21.7",
     "typedoc": "^0.28.16",
     "typedoc-plugin-missing-exports": "^4.1.2",
     "typescript": "^5.9.3",


### PR DESCRIPTION
### 🔗 Linked issue

- https://github.com/rolldown/tsdown/issues/276

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An issue with the currently used version of `tsdown` keep the static `import "node:module"` that break most frontend builds. It has been fixed in latest version.

```
Error: Unable to resolve module node:module from /Users/expo/workingdir/build/node_modules/@vinejs/vine/build/simple_error_reporter-DjITOpes.js: node:module could not be found within the project or in these directories:
```

This PR bumps tsdown version.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
