### PR TITLE
feat: substitue nested field names in custom message

### DIFF
--- a/src/messages_provider/simple_messages_provider.ts
+++ b/src/messages_provider/simple_messages_provider.ts
@@ -114,7 +114,7 @@ export class SimpleMessagesProvider implements MessagesProviderContact {
    * // Returns: "The username must be at least 5 characters"
    */
   getMessage(rawMessage: string, rule: string, field: FieldContext, args?: Record<string, any>) {
-    const fieldName = this.#fields[field.name] || field.name
+    const fieldName = this.#fields[field.getFieldPath()] || this.#fields[field.name] || field.name
 
     /**
      * 1st priority: Field-specific messages (highest specificity)

--- a/tests/unit/simple_messages_provider.spec.ts
+++ b/tests/unit/simple_messages_provider.spec.ts
@@ -87,6 +87,26 @@ test.group('Simple messages provider | resolving fields', () => {
     )
   })
 
+  test('substitue nested field name in custom message', ({ assert }) => {
+    const provider = new SimpleMessagesProvider(
+      {
+        required: 'The {{ field }} field is required',
+      },
+      {
+        'auth.username': 'nested user name',
+        'username': 'root user name',
+      }
+    )
+
+    const field = fieldContext.create('auth.username', undefined)
+    field.name = 'username'
+
+    assert.equal(
+      provider.getMessage('Enter value', 'required', field),
+      'The nested user name field is required'
+    )
+  })
+
   test('substitue field name in field message', ({ assert }) => {
     const provider = new SimpleMessagesProvider(
       {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I faced a problem on my project with translating nested json fields with the same nested key. Renaming keys to make them different is not an option.

Simple example:

```ts
const schema = vine.create({
  auth: vine.object({
    name: vine.string(),
  }),
  profile: vine.object({
    name: vine.string(),
  }),
})

schema.validate(
  {},
  {
    messagesProvider: new SimpleMessagesProvider(
      {
        required: '{{field}} is required',
      },
      {
        // these two lines don't work in current version, but to me they should
        'auth.name': 'Auth name',
        'profile.name': 'Profile name',

        'name': 'Any name', // it works, but has no flexibility
      }
    ),
  }
)
```

My fix is pretty straightforward: use `this.#fields[field.getFieldPath()]` as the highest priority on top of the current name resolution queue. This solution provides more flexibility while maintaining full backward compatibility.

What do you think?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
