### PR TITLE
fix: return Standard Schema issue.path as an array of segments

### DIFF
--- a/src/vine/validator.ts
+++ b/src/vine/validator.ts
@@ -324,7 +324,14 @@ export class VineValidator<
         issues: error?.messages.map((message: any) => {
           return {
             ...message,
-            path: message.field,
+            /**
+             * The Standard Schema spec requires `path` to be a
+             * `ReadonlyArray<PropertyKey | PathSegment>`. `message.field` is a
+             * dotted string (e.g. "user.name"), so we split it into segments.
+             * Otherwise consumers that iterate `path` (e.g. TanStack Form) walk
+             * the array-like string character by character and misattach errors.
+             */
+            path: typeof message.field === 'string' ? message.field.split('.') : message.field,
           }
         }),
       }

--- a/tests/integration/validator.spec.ts
+++ b/tests/integration/validator.spec.ts
@@ -496,16 +496,31 @@ test.group('Validator | standard validator', () => {
       {
         field: 'name',
         message: 'The name field must be defined',
-        path: 'name',
+        path: ['name'],
         rule: 'required',
       },
       {
         field: 'email',
         message: 'The email field must be defined',
-        path: 'email',
+        path: ['email'],
         rule: 'required',
       },
     ])
+  })
+
+  test('return nested field path as an array per standard validator spec', async ({ assert }) => {
+    const validator = vine.create(
+      vine.object({
+        user: vine.object({
+          name: vine.string(),
+        }),
+      })
+    )
+
+    const result = await validator['~standard'].validate({ user: {} })
+
+    assert.isDefined(result.issues)
+    assert.deepEqual(result.issues![0].path, ['user', 'name'])
   })
 
   test('return validated output as per standard validator spec', async ({


### PR DESCRIPTION
## Summary

Fixes #146.

VineJS's Standard Schema V1 adapter (`src/vine/validator.ts`) set each `issue.path` to `message.field`, which is a dotted string (e.g. `"user.name"`). The [Standard Schema spec](https://github.com/standard-schema/standard-schema/blob/main/packages/spec/src/index.ts) requires `path` to be a `ReadonlyArray<PropertyKey | PathSegment>`, not a string.

Because a JS string is array-like (`length` + numeric indices), consumers that iterate `path` -- notably **TanStack Form** -- walk the string character by character (`"u"`, `"s"`, `"e"`, `"r"`, ...) instead of by segment. Validation fails silently: errors are never attached to the right fields, making VineJS unusable as a TanStack Form validator without a runtime monkey-patch.

## Change

Split the dotted field string into segments so `path` is an array, matching the issue's expected output (`["user", "name"]`):

```ts
path: typeof message.field === 'string' ? message.field.split('.') : message.field,
```

## Tests (red -> green)

- Updated the two pre-existing assertions in `tests/integration/validator.spec.ts` that encoded the bug (`path: 'name'` / `path: 'email'` -> `['name']` / `['email']`).
- Added a nested-object test: a `vine.object({ user: vine.object({ name: vine.string() }) })` schema validated against `{ user: {} }` now asserts `issues[0].path` deep-equals `['user', 'name']`.

Reverting the one-line fix (keeping the new test) makes the nested test fail with `expected 'user.name' to deeply equal [ 'user', 'name' ]`; with the fix, the full suite, lint, typecheck, and prettier all pass.

## Known limitation (out of scope)

`.split('.')` over-splits field names that contain literal dots and yields string indices for array segments rather than numbers. A fully structured segment array (carrying real `PropertyKey` number/string segments end-to-end from the compiler) would be a larger change; this PR is the minimal, spec-conformant fix for the reported TanStack Form breakage.

---

This change was prepared with AI assistance and reviewed by me before submission.