### PR TITLE
use exclusiveMinimum instead of minimum for positiveRule

### DIFF
--- a/src/schema/number/rules.ts
+++ b/src/schema/number/rules.ts
@@ -127,7 +127,7 @@ export const positiveRule = createRule(
   },
   {
     toJSONSchema: (schema) => {
-      schema.minimum = 0
+      schema.exclusiveMinimum = 0
     },
   }
 )

--- a/tests/integration/json_schema.spec.ts
+++ b/tests/integration/json_schema.spec.ts
@@ -268,7 +268,7 @@ test.group('JsonSchema', () => {
         'positive',
         vine.number().positive(),
         [
-          [0, true],
+          [0, false],
           [100, true],
           [0.12, true],
           [-20, false],

--- a/tests/unit/json_schema.spec.ts
+++ b/tests/unit/json_schema.spec.ts
@@ -77,7 +77,7 @@ test.group('JsonSchema', () => {
         vine.number().range([12, 36]),
         { type: 'number', minimum: 12, maximum: 36 },
       ],
-      ['positive()', vine.number().positive(), { type: 'number', minimum: 0 }],
+      ['positive()', vine.number().positive(), { type: 'number', exclusiveMinimum: 0 }],
       ['negative()', vine.number().negative(), { type: 'number', exclusiveMaximum: 0 }],
       ['withoutDecimals()', vine.number().withoutDecimals(), { type: 'integer' }],
       ['in([3, 1, 8])', vine.number().in([3, 1, 8]), { type: 'number', enum: [3, 1, 8] }],


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/vinejs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Fixes #151 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

To match the documentation of `vine.number().positive()`
 
 > Enforces the value to be a positive number (greater than 0).
 > Zero is considered neutral and will fail this validation.
 
 The standard schema should be use  `exclusiveMinimum: 0` instead of `minimum: 0`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
